### PR TITLE
Missing comma on country table sql dump.

### DIFF
--- a/schema/codelists.sql
+++ b/schema/codelists.sql
@@ -1108,7 +1108,7 @@ INSERT INTO `Country` (`id`, `Code`, `Name`, `lang_id`) VALUES
 (647, 'ZM', 'ZAMBIE', 3),
 (648, 'ZW', 'ZIMBABWE', 3),
 (649, 'SS', 'SOUTH SUDAN', 1),
-(650, 'AN', 'NETHERLAND ANTILLES', 1)
+(650, 'AN', 'NETHERLAND ANTILLES', 1),
 (651, 'XK', 'KOSOVO', 1);
 
 -- --------------------------------------------------------


### PR DESCRIPTION
fixes #46 , sql dump import failed due to a missing comma. This caused all preceding tables to be empty and that lead to authentication problems.
